### PR TITLE
More spacing after leading emoji

### DIFF
--- a/quokka/cli.py
+++ b/quokka/cli.py
@@ -114,14 +114,14 @@ def init(name, destiny, source, theme, modules):
     # Copy project template from quokka root
     copyfolder(source, destiny)
     click.echo(
-        b('🐹 Quokka project created 🐹')
+        b('🐹  Quokka project created 🐹')
     )
-    lecho('📝 Name', name, green)
-    lecho('📁 Location', destiny, green)
+    lecho('📝  Name', name, green)
+    lecho('📁  Location', destiny, green)
     if source == project_template:
-        lecho('📚 Template', 'default', green)
+        lecho('📚  Template', 'default', green)
     else:
-        lecho('📚 Template', source, green)
+        lecho('📚  Template', source, green)
 
     # Fetch themes and extensions
     fetch_theme(theme, destiny)
@@ -137,9 +137,9 @@ def init(name, destiny, source, theme, modules):
     )
 
     click.echo(blue(f'➡ Go to {destiny}'))
-    click.echo(blue('⚙ run `quokka runserver` to start!'))
-    click.echo(blue('📄 Check the documentation on http://quokkaproject.org'))
-    click.echo(yellow('🐹 Happy Quokka! 🐹'))
+    click.echo(blue('⚙  Run `quokka runserver` to start!'))
+    click.echo(blue('📄  Check the documentation on http://quokkaproject.org'))
+    click.echo(yellow('🐹  Happy Quokka! 🐹'))
 
 
 @cli.command()

--- a/quokka/utils/project.py
+++ b/quokka/utils/project.py
@@ -3,18 +3,18 @@ from .echo import green, lecho, red
 
 def fetch_theme(theme, destiny):
     """TODO: implement this"""
-    lecho('🎨 Warning', f'{theme} theme not installed', red)
+    lecho('🎨  Warning', f'{theme} theme not installed', red)
     return
     if theme:
-        lecho('🎨 Theme installed', theme, green)
+        lecho('🎨  Theme installed', theme, green)
 
 
 def fetch_modules(modules, destiny):
     """TODO: implement this"""
-    lecho('🚚 Warning', f'{modules} modules not installed', red)
+    lecho('🚚  Warning', f'{modules} modules not installed', red)
     return
     if modules:
-        lecho('🚚 Modules installed', modules, green)
+        lecho('🚚  Modules installed', modules, green)
 
 
 def cookiecutter(*args, **kwargs):

--- a/quokka/utils/project.py
+++ b/quokka/utils/project.py
@@ -18,4 +18,4 @@ def fetch_modules(modules, destiny):
 
 
 def cookiecutter(*args, **kwargs):
-    lecho('🔧 Warning:', 'Config file not written', red)
+    lecho('🔧  Warning:', 'Config file not written', red)


### PR DESCRIPTION
At least on my Mac terminal (iTerm2 and Terminal,) emoji are double-wide, leading to cramped and ugly messaging.

Looks like this:

![image](https://user-images.githubusercontent.com/1833896/31105771-70bc7720-a7b4-11e7-96ee-e0e05a79d48d.png)

This PR simply adds another space after all the leading emoji in the install CLI output messages for prettier output.